### PR TITLE
Fix Get Balance Crash

### DIFF
--- a/lib/src/domain/services/wallet_service.dart
+++ b/lib/src/domain/services/wallet_service.dart
@@ -88,10 +88,10 @@ class WalletService extends Wallet {
   Future<Map<String, String>> getKeys() => _currentWallet.getKeys();
 
   @override
-  Future<int> getFullBalance() => _currentWallet.getFullBalance();
+  int getFullBalance() => _currentWallet.getFullBalance();
 
   @override
-  Future<int> getUnlockedBalance() => _currentWallet.getUnlockedBalance();
+  int getUnlockedBalance() => _currentWallet.getUnlockedBalance();
 
   @override
   int getCurrentHeight() => _currentWallet.getCurrentHeight();

--- a/lib/src/stores/balance/balance_store.dart
+++ b/lib/src/stores/balance/balance_store.dart
@@ -134,8 +134,8 @@ abstract class BalanceStoreBase with Store {
       return;
     }
 
-    fullBalance = await _walletService.getFullBalance();
-    unlockedBalance = await _walletService.getUnlockedBalance();
+    fullBalance = _walletService.getFullBalance();
+    unlockedBalance = _walletService.getUnlockedBalance();
     await updateFiatBalance();
   }
 

--- a/lib/src/wallet/oxen/oxen_wallet.dart
+++ b/lib/src/wallet/oxen/oxen_wallet.dart
@@ -389,7 +389,6 @@ class OxenWallet extends Wallet {
       oxen_wallet.setListeners(_onNewBlock, _onNewTransaction);
 
   Future _onNewBlock(int height, int blocksLeft, double ptc) async {
-    print('Ryan: onNewBlock start.');
     try {
       await askForUpdateTransactionHistory();
       askForUpdateBalance();
@@ -411,7 +410,6 @@ class OxenWallet extends Wallet {
     } catch (e) {
       print(e.toString());
     }
-    print('Ryan: onNewBlock finish.');
   }
 
   void _setListeners() {
@@ -493,13 +491,11 @@ class OxenWallet extends Wallet {
   }
 
   Future _onNewTransaction() async {
-    print('Ryan: onNewTransaction start.');
     try {
       await askForUpdateTransactionHistory();
       askForUpdateBalance();
     } catch (e) {
       print(e.toString());
     }
-    print('Ryan: onNewTransaction finish.');
   }
 }

--- a/lib/src/wallet/wallet.dart
+++ b/lib/src/wallet/wallet.dart
@@ -36,9 +36,9 @@ abstract class Wallet {
 
   Future<Map<String, String>> getKeys();
 
-  Future<int> getFullBalance();
+  int getFullBalance();
 
-  Future<int> getUnlockedBalance();
+  int getUnlockedBalance();
 
   int getCurrentHeight();
 


### PR DESCRIPTION
Seems like a race condition in `SyncListener`.
The `_onNewBlock` is updating the transaction history and getting the balance. And the function itself is async. This could cause the crash by reading and writing at the same time.

This PR tries to implement the `getBalance` functions and `_onNewBlock`as CakeWallet does. Hope this can fix the issue.