### PR TITLE
Default public RPC node updates

### DIFF
--- a/assets/node_list.yml
+++ b/assets/node_list.yml
@@ -4,3 +4,5 @@
   uri: public-eu.optf.ngo:22023
 -
   uri: explorer.oxen.aussie-pools.com:18081
+-
+  uri: oxen-rpc.caliban.org:22023

--- a/assets/node_list.yml
+++ b/assets/node_list.yml
@@ -1,8 +1,6 @@
 -
-  uri: public.loki.foundation:22023
+  uri: public-na.optf.ngo:22023
 -
-  uri: freyr.imaginary.stream:22023
+  uri: public-eu.optf.ngo:22023
 -
-  uri: nodes.hashvault.pro:22023
--
-  uri: node.loki-pool.com:18081
+  uri: explorer.oxen.aussie-pools.com:18081


### PR DESCRIPTION
- Replace public.loki.foundation with public-eu.optf.ngo (same server,
  new name).
- Replace freyr.imaginary.stream with public-na.optf.ngo (same server,
  new name).
- Remove nodes.hashvault.pro, which seems to be non-functional.
- Replace node.loki-pool.com with explorer.oxen.aussie-pools.com (same
  operator; the old name has been defunct for a while).

Fixes #16 (the last part; the first parts are already fixed).