### PR TITLE
Correct regex matching of RPC nodes.

### DIFF
--- a/lib/src/stores/node_list/node_list_store.dart
+++ b/lib/src/stores/node_list/node_list_store.dart
@@ -68,8 +68,8 @@ abstract class NodeListBase with Store {
     }
   }
 
-  static final nodeAddrRE = RegExp('^[0-9a-zA-Z.]+\$');
-  static final nodePortRE = RegExp('^[0-9]{1,5}\$');
+  static final nodeAddrRE = RegExp('^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\$|^[-0-9a-zA-Z.]{1,253}\$');
+  static final nodePortRE = RegExp('^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$');
 
   void validateNodeAddress(String value, AppLocalizations l10n) {
     isValid = nodeAddrRE.hasMatch(value);


### PR DESCRIPTION
* Don't allow invalid IP addresses or port numbers.

* Allow hyphens in hostnames.

* Restrict the hostname length to 253 characters, as per RFC1035.

# Pull Request Checklist 

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/oxen-wallet/tree/trunk) branch
* [x] Ran ´dartfmt -w lib oxen_coin/lib´
* [x] All tests are passing
* [x] My changes are ready to be shipped to users

I recently made a similar (now approved) change to the Service Node Operators app.

I see you have created a separate pull-request to add `oxen-rpc.caliban.org` to the list of RPC nodes. Thanks for doing that and sorry for neglecting to do it myself. For some reason, I thought only of doing it in the `oxen-electron-gui-wallet` repo.